### PR TITLE
Add task metadata to actions. Bump version 1.2.0

### DIFF
--- a/action/ComputePathThroughPoses.action
+++ b/action/ComputePathThroughPoses.action
@@ -1,6 +1,7 @@
 #goal definition
 geometry_msgs/PoseStamped[] goals
 geometry_msgs/PoseStamped start
+fognav_msgs/Task[] tasks
 string planner_id
 bool use_start # If false, use current robot pose as path start, if true, use start above instead
 ---

--- a/action/ComputePathToPose.action
+++ b/action/ComputePathToPose.action
@@ -1,6 +1,7 @@
 #goal definition
 geometry_msgs/PoseStamped goal
 geometry_msgs/PoseStamped start
+TaskMetaData metadata
 string planner_id
 bool use_start # If false, use current robot pose as path start, if true, use start above instead
 ---

--- a/action/FollowPath.action
+++ b/action/FollowPath.action
@@ -1,5 +1,6 @@
 #goal definition
 nav_msgs/Path path
+TaskMetaData metadata
 string controller_id
 string goal_checker_id
 bool avoidance_path

--- a/msg/Geofence.msg
+++ b/msg/Geofence.msg
@@ -8,6 +8,8 @@ uint8 geofence_type
 geometry_msgs/Point[] corners # [POINTS] 3> points, local or gps
 geometry_msgs/Point origin # [CIRCLE/SQUARE]
 float32 radius # [CIRCLE/SQUARE] in meters. if x meters, square will be 2x by 2x
+float32 altitude_floor # above home position in meters
+float32 altitude_ceiling # above home position in meters
 
 bool no_fly_zone # If false, the inner area is allowed, if not, outer side
 bool altitude_absolute # If false, it will be from the launch altitude

--- a/msg/TaskMetaData.msg
+++ b/msg/TaskMetaData.msg
@@ -7,6 +7,9 @@ uint8 TASK_GO_TO_AND_LAND=1
 uint8 TASK_LAND=2
 uint8 TASK_WAIT=3
 uint8 TASK_RETURN_TO_LAUNCH=4
+uint8 TASK_GUIDED=5
+uint8 TASK_RESERVED_1=6
+uint8 TASK_RESERVED_2=7
 
 uint8 task_type
 # This is a placeholder for configuration of the task types. 
@@ -16,10 +19,10 @@ float64[8] params
 uint8 YAW_USE_FROM_TASK=0
 uint8 YAW_TOWARDS_WAYPOINT=1
 uint8 YAW_TOWARDS_HOME=2
-uint8 YAW_AWAY_FROM_HOME=2
 uint8 YAW_ALONG_TRAJECTORY=3
 uint8 YAW_TOWARDS_WAYPOINT_YAW_FIRST=4
 uint8 YAW_HOLD_CURRENT=5
+uint8 YAW_AWAY_FROM_HOME=6
 uint8 yaw_mode
 
 uint8 TASK_STATUS_NOT_STARTED=0

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fognav_msgs</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>TODO: Package description</description>
   <maintainer email="mehmet.killioglu@unikie.com">Mehmet Killioglu</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## Changelog:
- Added task or task metadata into some internal action message requests
- fix yaw mode enum in the task metadata
- added altitude ceiling and floor for the geofence calls
- bump version to 1.2.0